### PR TITLE
readme: add shards install

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -26,9 +26,9 @@ export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/opt/openssl/lib/pkgconfig
 ## Running Specs
 
 1. Ensure redis is running: `redis-server`
-1. Install dependencies: `cd engine-drivers; shards install`
-2. Launch application: `crystal run ./src/app.cr`
-3. Browse to: http://localhost:3000/
+2. Install dependencies: `cd engine-drivers; shards update`
+3. Launch application: `crystal run ./src/app.cr`
+4. Browse to: http://localhost:3000/
 
 Now you can build drivers and run specs:
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -26,6 +26,7 @@ export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/opt/openssl/lib/pkgconfig
 ## Running Specs
 
 1. Ensure redis is running: `redis-server`
+1. Install dependencies: `cd engine-drivers; shards install`
 2. Launch application: `crystal run ./src/app.cr`
 3. Browse to: http://localhost:3000/
 


### PR DESCRIPTION
without `shards install`:
```
$ crystal run ./src/app.cr 
Error in src/app.cr:2: while requiring "./config"

require "./config"
^

in src/config.cr:2: can't find file 'action-controller'

If you're trying to require a shard:
- Did you remember to run `shards install`?
- Did you make sure you're running the compiler in the same directory as your shard.yml?

require "action-controller"
^
```